### PR TITLE
20240609: Adapt to the latest Raindrop API.

### DIFF
--- a/pkg/raindrop/client_test.go
+++ b/pkg/raindrop/client_test.go
@@ -61,14 +61,18 @@ func TestClient_GetAuthorizationURL(t *testing.T) {
 func Test_GetRaindrops(t *testing.T) {
 	// Given
 	raindrop1 := Raindrop{
-		Tags:  []string{"foo", "bar"},
-		Title: "Test 1",
-		Link:  "https://example.com/1",
+		RaindropUserInfo: RaindropUserInfo{
+			Tags:  []string{"foo", "bar"},
+			Title: "Test 1",
+			Link:  "https://example.com/1",
+		},
 	}
 	raindrop2 := Raindrop{
-		Tags:  []string{"baz"},
-		Title: "Test 2",
-		Link:  "https://example.com/2",
+		RaindropUserInfo: RaindropUserInfo{
+			Tags:  []string{"baz"},
+			Title: "Test 2",
+			Link:  "https://example.com/2",
+		},
 	}
 	expected := MultiRaindropsResponse{
 		Result: true,
@@ -358,9 +362,11 @@ func Test_GetTags(t *testing.T) {
 func Test_GetTaggedRaindrops(t *testing.T) {
 	// Given
 	raindrop1 := Raindrop{
-		Tags:  []string{"foo", "bar"},
-		Title: "Test 1",
-		Link:  "https://example.com/1",
+		RaindropUserInfo: RaindropUserInfo{
+			Tags:  []string{"foo", "bar"},
+			Title: "Test 1",
+			Link:  "https://example.com/1",
+		},
 	}
 	expected := MultiRaindropsResponse{
 		Result: true,


### PR DESCRIPTION
 - Reorganize import statements in client.go
 - Add comments to clarify the purpose of endpoint constants
 - Rename `user` struct to `UserRef` and add `Ref` field
 - Add `Type` field to `media` struct
 - Introduce `CollectionRef`, `RaindropUserInfo`, `RaindropAttach`, `Highlight`, `CreatorRef`, `AttachFileInfo`, `RaindropCache`, and `Reminder` structs for better data representation
 - Update `Raindrop` struct to embed `RaindropUserInfo` and `RaindropAttach`
 - Implement `GetRaindrop` method to fetch a single raindrop by ID
 - Add `CreateRaindrop` method to create a new raindrop with detailed information
 - Update test cases in client_test.go to reflect changes in `Raindrop` struct